### PR TITLE
Unless events share search, share one event

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -36,6 +36,9 @@
             <input type="hidden" name="page" value="{{ page.name }}">
 
             {% include "./user_form_wrapper.html" %}
+            {% if page.custom_fields.simplelist %}
+            <input type=select name="action_advocacy_team" value="" />
+            {% endif %}
 {% if page.custom_fields.all_lists %}
 <h3>What do you want to hear from us?</h3>
 <input type="checkbox" name="lists" value="1" checked /> Action Alerts (weekly)<br />

--- a/signup.html
+++ b/signup.html
@@ -37,7 +37,7 @@
 
             {% include "./user_form_wrapper.html" %}
             {% if page.custom_fields.simplelist %}
-            <input type=select name="action_advocacy_team" value="" />
+            <input type=select name="action_advocacy_team" id="id_action_advocacy_team" value="" />
             {% endif %}
 {% if page.custom_fields.all_lists %}
 <h3>What do you want to hear from us?</h3>

--- a/wrapper.html
+++ b/wrapper.html
@@ -15,7 +15,7 @@
     {{ page.followup.share_image_tag }}
    
     {% ifequal page.type 'EventSignup' %}
-        {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} <meta property="og:url" content="page.name" />{% endif %}
+        {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} <meta property="og:url" content="{{ page.name }}" />{% endif %}
     {% else %}
     {{ page.followup.share_url_tag }}
     {% endifequal %}{% endif %}

--- a/wrapper.html
+++ b/wrapper.html
@@ -15,7 +15,7 @@
     {{ page.followup.share_image_tag }}
    
     {% ifequal page.type 'EventSignup' %}
-        {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} <meta property="og:url" content="https://act.fcnl.org/event/{{ page.name }}/{{ page.campaign_id }}/signup" />{% endif %}
+        {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} <meta property="og:url" content="https://act.fcnl.org/event/{{ page.name }}/{{ page.campaign_id.event_id }}/signup" />{% endif %}
     {% else %}
     {{ page.followup.share_url_tag }}
     {% endifequal %}{% endif %}

--- a/wrapper.html
+++ b/wrapper.html
@@ -15,7 +15,7 @@
     {{ page.followup.share_image_tag }}
    
     {% ifequal page.type 'EventSignup' %}
-        {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} <meta property="og:url" content="{{ page.name }}" />{% endif %}
+        {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} <meta property="og:url" content="https://act.fcnl.org/event/{{ page.name }}/{{ page.page_ptr_id }}/signup" />{% endif %}
     {% else %}
     {{ page.followup.share_url_tag }}
     {% endifequal %}{% endif %}

--- a/wrapper.html
+++ b/wrapper.html
@@ -15,7 +15,7 @@
     {{ page.followup.share_image_tag }}
    
     {% ifequal page.type 'EventSignup' %}
-        {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} <meta property="og:url" content="https://act.fcnl.org/event/{{ page.name }}/{{ events_event.id }}/signup" />{% endif %}
+        {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} <meta property="og:url" content="https://act.fcnl.org/event/{{ page.name }}/{{ page.events_event.id }}/signup" />{% endif %}
     {% else %}
     {{ page.followup.share_url_tag }}
     {% endifequal %}{% endif %}

--- a/wrapper.html
+++ b/wrapper.html
@@ -15,7 +15,7 @@
     {{ page.followup.share_image_tag }}
    
     {% ifequal page.type 'EventSignup' %}
-        {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} <meta property="og:url" content="https://act.fcnl.org/event/{{ page.name }}/{{ page.events_event.id }}/signup" />{% endif %}
+        {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} <meta property="og:url" content="https://act.fcnl.org/event/{{ page.name }}/{{ page.events_campaign.id }}/signup" />{% endif %}
     {% else %}
     {{ page.followup.share_url_tag }}
     {% endifequal %}{% endif %}

--- a/wrapper.html
+++ b/wrapper.html
@@ -15,7 +15,7 @@
     {{ page.followup.share_image_tag }}
    
     {% ifequal page.type 'EventSignup' %}
-        {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} <meta property="og:url" content="https://act.fcnl.org/event/{{ page.name }}/{{ page.events_campaign.id }}/signup" />{% endif %}
+        {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} <meta property="og:url" content="https://act.fcnl.org/event/{{ page.name }}/{{ page.campaign_id }}/signup" />{% endif %}
     {% else %}
     {{ page.followup.share_url_tag }}
     {% endifequal %}{% endif %}

--- a/wrapper.html
+++ b/wrapper.html
@@ -16,7 +16,7 @@
    
     {% ifequal page.type 'EventSignup' %}
         {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} 
-        <meta property="og:url" content="https://act.fcnl.org/event/{{ page.name }}/{{ page.campaign_id.event.id }}/signup" />{% endif %}
+        <meta property="og:url" content="https://act.fcnl.org/event/{{ page.name }}/{{ page.campaign_id.events_event.id }}/signup" />{% endif %}
     {% else %}
     {{ page.followup.share_url_tag }}
     {% endifequal %}{% endif %}

--- a/wrapper.html
+++ b/wrapper.html
@@ -16,7 +16,7 @@
    
     {% ifequal page.type 'EventSignup' %}
         {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} 
-        <meta property="og:url" content="https://act.fcnl.org/event/{{ page.name }}/{{ page.campaign_id.events_event.id }}/signup" />{% endif %}
+        <meta property="og:url" content="https://act.fcnl.org/event/{{ page.name }}/{{ event.id }}/signup" />{% endif %}
     {% else %}
     {{ page.followup.share_url_tag }}
     {% endifequal %}{% endif %}

--- a/wrapper.html
+++ b/wrapper.html
@@ -13,8 +13,8 @@
     {% else %}{{ page.followup.share_title_tag }}
     {% if form.id and page.followup.share_description_value %}<meta name="description" property="og:description" content="{% block description %}{{ page.followup.share_description_value }}{% endblock %}">{% else %}<meta name="description" property="og:description" content="Act now to support peace and justice.">{% endif %}
     {{ page.followup.share_image_tag }}
-   {{ page.type }}
-    {% ifequal page.type 'event' %}
+   
+    {% ifequal page.type 'EventSignup' %}
         {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} <meta property="og:url" content="page.name" />{% endif %}
     {% else %}
     {{ page.followup.share_url_tag }}

--- a/wrapper.html
+++ b/wrapper.html
@@ -18,7 +18,7 @@
         {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} <meta property="og:url" content="page.name" />{% endif %}
     {% else %}
     {{ page.followup.share_url_tag }}
-    {% endif %}{% endif %}
+    {% endifequal %}
     <meta property="og:site_name" content="{% filter ak_text:'org_name' %}{% client_name %}{% endfilter %}">
     <meta property="og:type" content="article">
     <meta name="twitter:card" value="summary">

--- a/wrapper.html
+++ b/wrapper.html
@@ -15,7 +15,7 @@
     {{ page.followup.share_image_tag }}
    
     {% ifequal page.type 'EventSignup' %}
-        {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} <meta property="og:url" content="https://act.fcnl.org/event/{{ page.name }}/{{ page.page_ptr_id }}/signup" />{% endif %}
+        {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} <meta property="og:url" content="https://act.fcnl.org/event/{{ page.name }}/{{ events_event.id }}/signup" />{% endif %}
     {% else %}
     {{ page.followup.share_url_tag }}
     {% endifequal %}{% endif %}

--- a/wrapper.html
+++ b/wrapper.html
@@ -15,7 +15,8 @@
     {{ page.followup.share_image_tag }}
    
     {% ifequal page.type 'EventSignup' %}
-        {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} <meta property="og:url" content="https://act.fcnl.org/event/{{ page.name }}/{{ page.campaign_id.event_id }}/signup" />{% endif %}
+        {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} 
+        <meta property="og:url" content="https://act.fcnl.org/event/{{ page.name }}/{{ page.campaign_id.event.id }}/signup" />{% endif %}
     {% else %}
     {{ page.followup.share_url_tag }}
     {% endifequal %}{% endif %}

--- a/wrapper.html
+++ b/wrapper.html
@@ -13,7 +13,12 @@
     {% else %}{{ page.followup.share_title_tag }}
     {% if form.id and page.followup.share_description_value %}<meta name="description" property="og:description" content="{% block description %}{{ page.followup.share_description_value }}{% endblock %}">{% else %}<meta name="description" property="og:description" content="Act now to support peace and justice.">{% endif %}
     {{ page.followup.share_image_tag }}
-    {{ page.followup.share_url_tag }}{% endif %}
+   {{ page.type }}
+    {% ifequal page.type 'event' %}
+        {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} <meta property="og:url" content="page.name" />{% endif %}
+    {% else %}
+    {{ page.followup.share_url_tag }}
+    {% endif %}{% endif %}
     <meta property="og:site_name" content="{% filter ak_text:'org_name' %}{% client_name %}{% endfilter %}">
     <meta property="og:type" content="article">
     <meta name="twitter:card" value="summary">

--- a/wrapper.html
+++ b/wrapper.html
@@ -18,7 +18,7 @@
         {% if page.custom_fields.share_event_search %}{{ page.followup.share_url_tag }}{% else %} <meta property="og:url" content="page.name" />{% endif %}
     {% else %}
     {{ page.followup.share_url_tag }}
-    {% endifequal %}
+    {% endifequal %}{% endif %}
     <meta property="og:site_name" content="{% filter ak_text:'org_name' %}{% client_name %}{% endfilter %}">
     <meta property="og:type" content="article">
     <meta name="twitter:card" value="summary">


### PR DESCRIPTION
For most events, we want shares to go directly to the event in question, not the search page. Unless the custom field "share_event_search" exists, this will force shares to the event, not the event search.